### PR TITLE
Fixes to string generation and lookup

### DIFF
--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -193,7 +193,7 @@ class I18NPlugin(Plugin):
                             else:
                                 is_content=True
                         if is_content:
-                            f.write("%s"%translator.gettext(line).encode('utf-8') )
+                            f.write("%s\n"%translator.gettext(stripped_line).encode('utf-8') )
 
 
     def on_after_build(self, builder, build_state, source, prog):

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -197,7 +197,7 @@ class I18NPlugin(Plugin):
 
 
     def on_after_build(self, builder, build_state, source, prog):
-        if isinstance(source,Page):
+        if isinstance(source,Page) and source.alt == PRIMARY_ALT:
             try:
                 text = source.contents.as_text()
             except IOError:


### PR DESCRIPTION
Currently if a field is a multi-line field, looking up of translation
fails leading to a default text being used.  This is due to new line
character at the end of the line.  Removing the new line leads to lookup
being successful.

Without the second fix, the following happens:
- The messages are extracted from English to .POT files.
- The messages are then translated to contents+xx.po and built.
- contents+xx.lr files are created.
- Next time when 'build' is run, messages from contents+xx.lr are also
  extracted back into .POT file.
