### PR TITLE
Add Python3 compatibility Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ So if your default content language is not english, you will have to edit the fi
 
 #### Lektor
 
-This plugin has been tested with `Lektor 2.3`.
+This plugin has been tested with `Lektor 3..0.x`.
 
 #### GetText
 
@@ -98,7 +98,7 @@ On macOS, use a decent package manager, like MacPorts or Homebrew. With Homebrew
 
     brew install gettext
 
-Specificaly, we will need to call the `msginit` program distributed with recent versions of gettext.
+Specifically, we will need to call the `msginit` program distributed with recent versions of gettext.
 
 ### Installation
 


### PR DESCRIPTION
Hi,

we use Lektor with Python3, hence it made sense to port this plugin to Python3. To maintain backward compatibility, I update the script so that it runs with both Python2 and 3. I have to admit that I only used the Python3-part, but the diff should make obvious that I didn't make intrusive changes and if required, I'll try to set up a python2-lektor here to test my changes.

If you accept this PR, please release a new version so that we can make use of Lektor's plugin manager.

Thanks