### PR TITLE
Enable plugin pot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ The idea of this plugin is to capture the **sentences** from your **content**, a
     content = en
     translations = fr,es,it
     i18npath = i18n
+    translate_paragraphwise = False
 
 Where :
 
 * `content` is the language used to write `contents.lr` files (default is `en`)
 * `translations` is the list of target languages (you want to translate into).
 * `i18npath` is the directory where translation files will be produced/stored (default is `i18n`). This directory needs to be relative to root path.
+* `translate_paragraphwise` specifies whether translation strings are created per line or per paragraph. The latter is helpful for documents wrapping texts at 80 character boundaries. It is set to `False` by default.
 
 ### Translatable fields
 
@@ -90,15 +92,17 @@ This plugin has been tested with `Lektor 3..0.x`.
 
 #### GetText
 
-A recent vesion of GetText needs to be installed on the system. For a Debian/Ubuntu system, this means a simple :
+Both Gettext and Pybabel are required.  For a Debian/Ubuntu system, this means a simple :
 
-    sudo apt-get install gettext
+    sudo apt-get install gettext python3-babel
 
 On macOS, use a decent package manager, like MacPorts or Homebrew. With Homebrew:
 
     brew install gettext
 
-Specifically, we will need to call the `msginit` program distributed with recent versions of gettext.
+and then pip to fetch pybabel:
+
+    pip install babel
 
 ### Installation
 

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -180,7 +180,7 @@ def line_is_dashes(line):
 def split_paragraphs(document):
     if isinstance(document, (list, tuple)):
         document = ''.join(document) # list of lines
-    return re.split('\n(?:\s*\n){1,}', document)
+    return re.split('\n(?:\\s*\n){1,}', document)
 
 # We cannot check for unused arguments here, they're mandated by the plugin API.
 #pylint:disable=unused-argument
@@ -256,7 +256,7 @@ class I18NPlugin(Plugin):
                     chunks = (split_paragraphs(section) if self.trans_parwise
                             else [x.strip() for x in section if x.strip()])
                     for chunk in chunks:
-                        translations.add(chunk,
+                        translations.add(chunk.strip(),
                             "%s (%s:%s.%s)" % (
                                 urljoin(self.url_prefix, source.url_path),
                                 relpath(source.source_filename, root_path),

--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -256,7 +256,7 @@ class I18NPlugin(Plugin):
                     chunks = (split_paragraphs(section) if self.trans_parwise
                             else [x.strip() for x in section if x.strip()])
                     for chunk in chunks:
-                        translations.add(chunk.strip(),
+                        translations.add(chunk.strip('\r\n'),
                             "%s (%s:%s.%s)" % (
                                 urljoin(self.url_prefix, source.url_path),
                                 relpath(source.source_filename, root_path),
@@ -365,7 +365,7 @@ class I18NPlugin(Plugin):
         block and re-inject result."""
         result = []
         for paragraph in split_paragraphs(content):
-            stripped = paragraph.strip('\n')
+            stripped = paragraph.strip('\n\r')
             paragraph = paragraph.replace(stripped, trans(translator,
                     stripped))
             result.append(paragraph)


### PR DESCRIPTION
This enables an additional plugin.pot to reside in i18n/ so that the gettext infrastructure can be reused to enable localisation of additional plugins.