### PR TITLE
Create a unique temp file

### DIFF
--- a/lektor_i18n.py
+++ b/lektor_i18n.py
@@ -426,10 +426,18 @@ class I18NPlugin(Plugin):
                 self.process_node(fields, sections, source, source.datamodel.id, builder.env.root_path)
 
 
+    def get_templates_pot_filename(self):
+        try:
+            return self.pot_templates_filename
+        except AttributeError:
+            self.pot_templates_file = tempfile.NamedTemporaryFile(suffix=".pot",prefix="templates-")
+            self.pot_templates_filename = self.pot_templates_file.name
+            return self.pot_templates_filename
+
     def on_before_build_all(self, builder, **extra):
         if self.enabled:
             reporter.report_generic("i18n activated, with main language %s"% self.content_language )
-            templates_pot_filename = join(tempfile.gettempdir(), 'templates.pot')
+            templates_pot_filename = self.get_templates_pot_filename()
             reporter.report_generic("Parsing templates for i18n into %s" \
                     % relpath(templates_pot_filename, builder.env.root_path))
             translations.parse_templates(templates_pot_filename)
@@ -443,7 +451,7 @@ class I18NPlugin(Plugin):
             return
         contents_pot_filename = join(builder.env.root_path, self.i18npath, 'contents.pot')
         pots = [contents_pot_filename,
-                join(tempfile.gettempdir(), 'templates.pot'),
+                self.get_templates_pot_filename(),
                 join(builder.env.root_path, self.i18npath, 'plugins.pot')]
         # write out contents.pot from web site contents
         translations.write_pot(pots[0], self.content_language)
@@ -458,5 +466,3 @@ class I18NPlugin(Plugin):
         for language in self.translations_languages:
             po_file=POFile(language, self.i18npath)
             po_file.generate()
-
-


### PR DESCRIPTION
lektor-i18n-plugin used the file /tmp/templates.pot in its workings.
(Where /tmp/ could be something else as returned by tempfile.gettempdir()).

Using a fixed name for a "temporary" file in a directory that is
writable by other users is a security issue.  Further, using the same
file in multiple (parallel) runs of lektor may lead to undesired
results.

Hence, we now use a proper tempfile as created by
tempfile.NamedTemporaryFile().